### PR TITLE
modified __init__ to fix relative importing for Python3

### DIFF
--- a/library/envirophat/__init__.py
+++ b/library/envirophat/__init__.py
@@ -1,9 +1,9 @@
-from i2c_bus import bus
-from tcs3472 import tcs3472
-from bmp280 import bmp280
-from ads1015 import ads1015
-from lsm303d import lsm303d
-from leds import leds
+from .i2c_bus import bus
+from .tcs3472 import tcs3472
+from .bmp280 import bmp280
+from .ads1015 import ads1015
+from .lsm303d import lsm303d
+from .leds import leds
 
 leds = leds()
 light = tcs3472(bus)


### PR DESCRIPTION
Currently installation won't work with Python3. When you try to import the envirophat library under Python3 it fails with the error:

ImportError: No module named 'i2c_bus'

This is because relative path importing is removed in Python3.x (still works in Python2.x)

Adding the . before the library name in **init**.py is s simple fix (or you could use the absolute path e.g

from envirophat.i2c_bus import bus

)
