### PR TITLE
Defer setup to avoid module import-time side-effects

### DIFF
--- a/library/envirophat/__init__.py
+++ b/library/envirophat/__init__.py
@@ -1,15 +1,62 @@
 from .i2c_bus import bus
-from .ads1015 import ads1015
-from .bmp280 import bmp280
-from .leds import leds
-from .lsm303d import lsm303d
-from .tcs3472 import tcs3472
+from .ads1015 import ads1015 as _ads1015
+from .bmp280 import bmp280 as _bmp280
+from .leds import leds as _leds
+from .lsm303d import lsm303d as _lsm303d
+from .tcs3472 import tcs3472 as _tcs3472
 
 
 __version__ = '0.0.6'
 
-leds = leds()
-light = tcs3472(bus)
-weather = bmp280(bus)
-analog = ads1015(bus)
-motion = lsm303d(bus)
+
+_is_setup = False
+
+
+class Default(object):
+    """Default class to catch calls and ensure one-time setup.
+    """
+
+    def __init__(self, parent_name=None, **kwargs):
+        object.__init__(self)
+        self._parent_name = parent_name
+
+    def _ensure_setup(self):
+        if not _is_setup:
+            setup()
+        self._ensure_setup = lambda: globals()[self._parent_name]
+        return globals()[self._parent_name]
+
+    def __getattribute__(self, name):
+        if name in ["_ensure_setup", "_parent_name"]:
+             return object.__getattribute__(self, name)
+
+        return self._ensure_setup().__getattribute__(name)
+
+    def __repr__(self):
+        return self._ensure_setup().__repr__()
+
+    def __getitem__(self, item):
+        return self._ensure_setup()[item]
+
+
+leds = Default('leds')
+light = Default('light')
+weather = Default('weather')
+analog = Default('analog')
+motion = Default('motion')
+
+
+def setup():
+    global _is_setup, leds, light, weather, analog, motion
+
+    if _is_setup:
+        raise RuntimeError("")
+
+    leds = _leds()
+    light = _tcs3472(bus)
+    weather = _bmp280(bus)
+    analog = _ads1015(bus)
+    motion = _lsm303d(bus)
+
+    _is_setup = True
+

--- a/library/envirophat/ads1015.py
+++ b/library/envirophat/ads1015.py
@@ -18,8 +18,9 @@ PGA_1_024V = 1024
 PGA_0_512V = 512
 PGA_0_256V = 256
 
-class ads1015:
+class ads1015(object):
     def __init__(self, i2c_bus=None, addr=ADDR):
+        object.__init__(self)
         self._over_voltage = [False] * 4
 
         self.i2c_bus = i2c_bus

--- a/library/envirophat/bmp280.py
+++ b/library/envirophat/bmp280.py
@@ -90,8 +90,9 @@ class signed_int(int):
             number -= 1 << bits
         return int.__new__(self, number)
 
-class bmp280:
+class bmp280(object):
     def __init__(self, i2c_bus=None, addr=ADDR):
+        object.__init__(self)
         self._temperature = 0
         self._pressure = 0
 

--- a/library/envirophat/leds.py
+++ b/library/envirophat/leds.py
@@ -5,14 +5,14 @@ try:
 except ImportError:
     exit("This library requires the RPi.GPIO module\nInstall with: sudo pip install RPi.GPIO")
 
-
-GPIO.setwarnings(False)
-GPIO.setmode(GPIO.BCM)
-GPIO.setup(4, GPIO.OUT)
-GPIO.output(4, 0)
-
-class leds:
+class leds(object):
     def __init__(self, status=0):
+        object.__init__(self)
+        GPIO.setwarnings(False)
+        GPIO.setmode(GPIO.BCM)
+        GPIO.setup(4, GPIO.OUT)
+        GPIO.output(4, 0)
+
         self.status = status
 
     def on(self):

--- a/library/envirophat/lsm303d.py
+++ b/library/envirophat/lsm303d.py
@@ -100,7 +100,7 @@ class vector:
     def __str__(self):
         return str((self.x, self.y, self.z))
 
-class lsm303d:
+class lsm303d(object):
     _mag = [0,0,0]
     _accel = [0,0,0]
     _tiltcomp = [0,0,0]
@@ -110,6 +110,7 @@ class lsm303d:
     _tilt_heading_degrees=0
 
     def __init__(self, i2c_bus=None, addr=ADDR):
+        object.__init__(self)
         self.i2c_bus = i2c_bus
         if not hasattr(i2c_bus, "write_byte_data") or not hasattr(i2c_bus, "read_byte_data"):
             raise TypeError("Object given for i2c_bus must implement write_byte_data and read_byte_data methods")

--- a/library/envirophat/tcs3472.py
+++ b/library/envirophat/tcs3472.py
@@ -27,8 +27,9 @@ CH_GREEN = 1
 CH_BLUE = 2
 CH_CLEAR = 3
 
-class tcs3472:
+class tcs3472(object):
     def __init__(self, i2c_bus=None, addr=ADDR):
+        object.__init__(self)
         self.addr = addr
         self.i2c_bus = i2c_bus
         if not hasattr(i2c_bus, "read_word_data") or not hasattr(i2c_bus, "write_byte_data"):


### PR DESCRIPTION
This PR makes several "friendly neighbour" changes to the Enviro pHAT library:

* Do not perform any module setup on import
* Do not output any messages/text on import
* Use ImportError instead of hard exit() for "friendly" import error messages

See here for details of the problems import-time side-effects can have: https://www.raspberrypi.org/forums/viewtopic.php?f=32&t=193502&p=1212488#p1212488