### PR TITLE
Converted Pa to hPa

### DIFF
--- a/examples/all.py
+++ b/examples/all.py
@@ -21,7 +21,7 @@ try:
 
         output = """
 Temp: {t}c
-Pressure: {p}Pa
+Pressure: {p}hPa
 Light: {c}
 RGB: {r}, {g}, {b} 
 Heading: {h}
@@ -31,7 +31,7 @@ Analog: 0: {a0}, 1: {a1}, 2: {a2}, 3: {a3}
 
 """.format(
         t = round(weather.temperature(),2),
-        p = round(weather.pressure(),2),
+        p = round(weather.pressure()/100,2),
         c = light.light(),
         r = rgb[0],
         g = rgb[1],

--- a/library/envirophat/bmp280.py
+++ b/library/envirophat/bmp280.py
@@ -153,7 +153,7 @@ class bmp280:
         """Return the current air pressure."""
 
         self.update()
-        return self._pressure
+        return self._pressure / 100.0
 
     def altitude(self, qnh=QNH):
         """Return the current approximate altitude.
@@ -161,7 +161,7 @@ class bmp280:
         :param qnh: Your local value for atmospheric pressure adjusted to sea level.
 
         """
-        return 44330.0 * (1.0 - pow(self.pressure() / (qnh*100), (1.0/5.255))) # Calculate altitute from pressure & qnh
+        return 44330.0 * (1.0 - pow(self.pressure() / qnh, (1.0/5.255))) # Calculate altitute from pressure & qnh
 
     def update(self):
         """Update stored temperature and pressure values.


### PR DESCRIPTION
Your guide (https://learn.pimoroni.com/tutorial/sandyj/getting-started-with-enviro-phat) refers to pressure in hPa, but the sensor reports in Pa. Have divided the pressure data by 100 to convert to hPa, which also falls in line with the BME680 breakout board readings.