### PR TITLE
Defer setup to avoid module import-time side effects

### DIFF
--- a/library/envirophat/ads1015.py
+++ b/library/envirophat/ads1015.py
@@ -20,6 +20,7 @@ PGA_0_256V = 256
 
 class ads1015:
     def __init__(self, i2c_bus=None, addr=ADDR):
+        self._is_setup = False
         self._over_voltage = [False] * 4
 
         self.i2c_bus = i2c_bus

--- a/library/envirophat/ads1015.py
+++ b/library/envirophat/ads1015.py
@@ -1,8 +1,8 @@
 import time
 
 
-ADDR = 0x48
-ALT = 0x49
+ADDR = 0x49
+ALT = 0x48
 
 REG_CONV = 0x00
 REG_CFG = 0x01
@@ -27,15 +27,22 @@ class ads1015:
             raise TypeError("Object given for i2c_bus must implement write_i2c_block_data and read_i2c_block_data")
 
         self.addr = addr
-        self.max_voltage = 3300
-        self.default_gain = PGA_4_096V
-         
+        self.max_voltage = 5000
+        self.default_gain = PGA_6_144V
+
+    def setup(self):
+        if self._is_setup:
+            return
+        self._is_setup = True
+
+        # If a read fails to the addr for the 5v Enviro pHAT,
+        # switch over to the alternate address for old 3.3v
         try:
             self.i2c_bus.read_byte_data(self.addr, 0x00)
         except IOError:
             self.addr = ALT
-            self.max_voltage = 5000
-            self.default_gain = PGA_6_144V
+            self.max_voltage = 3300
+            self.default_gain = PGA_4_096V
 
     def read(self, channel=0, programmable_gain=None, samples_per_second=1600):
         """Read a specific ADC channel.
@@ -44,8 +51,11 @@ class ads1015:
         :param programmable_gain: Gain amount to use, one of 6144, 4096, 2048, 1024, 512 or 256 (default 4096 or 6144 depending on revision)
         :param samples_per_second: Samples per second, one of 128, 250, 498, 920, 1600, 2400, 3300 (default 1600)
         """
+        self.setup()
+
         if programmable_gain is None:
             programmable_gain = self.default_gain
+
         # sane defaults
         config = 0x0003 | 0x0100
 

--- a/library/envirophat/bmp280.py
+++ b/library/envirophat/bmp280.py
@@ -140,7 +140,7 @@ class bmp280(object):
         """
 
         if unit is None:
-            unit = "hPa"
+            unit = "Pa"
 
         self.update()
 

--- a/library/envirophat/bmp280.py
+++ b/library/envirophat/bmp280.py
@@ -93,39 +93,19 @@ class signed_int(int):
             number -= 1 << bits
         return int.__new__(self, number)
 
-class bmp280:
+class bmp280(object):
     def __init__(self, i2c_bus=None, addr=ADDR):
+        object.__init__(self)
+
         self._temperature = 0
         self._pressure = 0
 
         self.addr = addr
         self.i2c_bus = i2c_bus
+        self._is_setup = False
 
-        if not hasattr(i2c_bus, "write_byte_data") or not hasattr(i2c_bus, "read_byte_data"):
+        if getattr(i2c_bus, "write_byte_data", None) is None or getattr(i2c_bus, "read_byte_data", None) is None:
             raise TypeError("Object given for i2c_bus must implement write_byte_data and read_byte_data methods")
-
-        if self._read_byte(REGISTER_CHIPID) == 0x58: # check sensor id 0x58=BMP280
-            self._write_byte(REGISTER_SOFTRESET,0xB6) # reset sensor
-            time.sleep(0.2) # little break
-            self._write_byte(REGISTER_CONTROL,CTRL_MEAS) #
-            time.sleep(0.2) # little break
-            self._write_byte(REGISTER_CONFIG,CONFIG)  #
-            time.sleep(0.2)
-
-            self.dig_T1 = self._read_unsigned_word(REGISTER_DIG_T1) # read correction settings
-            self.dig_T2 = self._read_signed_word(REGISTER_DIG_T2)
-            self.dig_T3 = self._read_signed_word(REGISTER_DIG_T3)
-            self.dig_P1 = self._read_unsigned_word(REGISTER_DIG_P1)
-            self.dig_P2 = self._read_signed_word(REGISTER_DIG_P2)
-            self.dig_P3 = self._read_signed_word(REGISTER_DIG_P3)
-            self.dig_P4 = self._read_signed_word(REGISTER_DIG_P4)
-            self.dig_P5 = self._read_signed_word(REGISTER_DIG_P5)
-            self.dig_P6 = self._read_signed_word(REGISTER_DIG_P6)
-            self.dig_P7 = self._read_signed_word(REGISTER_DIG_P7)
-            self.dig_P8 = self._read_signed_word(REGISTER_DIG_P8)
-            self.dig_P9 = self._read_signed_word(REGISTER_DIG_P9)
-        else:
-            raise IOError("bmp280 not found on address {:x}".format(self.addr))
 
     def _write_byte(self, register, value):
         self.i2c_bus.write_byte_data(self.addr, register, value)
@@ -160,7 +140,7 @@ class bmp280:
         """
 
         if unit is None:
-            unit = "Pa"
+            unit = "hPa"
 
         self.update()
 
@@ -183,6 +163,32 @@ class bmp280:
         This function is called automatically when calling temperature() or pressure().
         
         """
+        if not self._is_setup:
+            if self._read_byte(REGISTER_CHIPID) == 0x58: # check sensor id 0x58=BMP280
+                self._write_byte(REGISTER_SOFTRESET,0xB6) # reset sensor
+                time.sleep(0.2) # little break
+                self._write_byte(REGISTER_CONTROL,CTRL_MEAS) #
+                time.sleep(0.2) # little break
+                self._write_byte(REGISTER_CONFIG,CONFIG)  #
+                time.sleep(0.2)
+
+                self.dig_T1 = self._read_unsigned_word(REGISTER_DIG_T1) # read correction settings
+                self.dig_T2 = self._read_signed_word(REGISTER_DIG_T2)
+                self.dig_T3 = self._read_signed_word(REGISTER_DIG_T3)
+                self.dig_P1 = self._read_unsigned_word(REGISTER_DIG_P1)
+                self.dig_P2 = self._read_signed_word(REGISTER_DIG_P2)
+                self.dig_P3 = self._read_signed_word(REGISTER_DIG_P3)
+                self.dig_P4 = self._read_signed_word(REGISTER_DIG_P4)
+                self.dig_P5 = self._read_signed_word(REGISTER_DIG_P5)
+                self.dig_P6 = self._read_signed_word(REGISTER_DIG_P6)
+                self.dig_P7 = self._read_signed_word(REGISTER_DIG_P7)
+                self.dig_P8 = self._read_signed_word(REGISTER_DIG_P8)
+                self.dig_P9 = self._read_signed_word(REGISTER_DIG_P9)
+            else:
+                raise IOError("bmp280 not found on address {:x}".format(self.addr))
+
+            self._is_setup = True
+
         raw_temp_msb=self._read_byte(REGISTER_TEMPDATA_MSB) # read raw temperature msb
         raw_temp_lsb=self._read_byte(REGISTER_TEMPDATA_LSB) # read raw temperature lsb
         raw_temp_xlsb=self._read_byte(REGISTER_TEMPDATA_XLSB) # read raw temperature xlsb
@@ -212,3 +218,4 @@ class bmp280:
 
         self._temperature = temp
         self._pressure = press
+

--- a/library/envirophat/tcs3472.py
+++ b/library/envirophat/tcs3472.py
@@ -29,6 +29,7 @@ CH_CLEAR = 3
 
 class tcs3472:
     def __init__(self, i2c_bus=None, addr=ADDR):
+        self._is_setup = False
         self.addr = addr
         self.i2c_bus = i2c_bus
         if not hasattr(i2c_bus, "read_word_data") or not hasattr(i2c_bus, "write_byte_data"):


### PR DESCRIPTION
This PR is a second attempt at #23 and makes several "friendly neighbour" changes to the Enviro pHAT library:

* Do not perform any module setup on import
* Do not output any messages/text on import
* Use ImportError instead of hard exit() for "friendly" import error messages

See here for details of the problems import-time side-effects can have: https://www.raspberrypi.org/forums/viewtopic.php?f=32&t=193502&p=1212488#p1212488

This PR also includes a tweak to make the revised, 5v-tolerant Enviro pHAT board version the primary version since by now it will be the more widespread of the two boards. The board detection will now fail back to the 3.3v version.